### PR TITLE
Wait when file is not written yet

### DIFF
--- a/lsassy/dumper.py
+++ b/lsassy/dumper.py
@@ -91,7 +91,7 @@ class Dumper:
             exit(1)
 
         try:
-            # self._conn.deleteFile(self._share, self._tmp_dir + self._remote_lsass_dump)
+            self._conn.deleteFile(self._share, self._tmp_dir + self._remote_lsass_dump)
             self._log.success('Deleted lsass dump')
         except Exception as e:
             self._log.error('Error deleting lsass dump : {}'.format(e))

--- a/lsassy/dumper.py
+++ b/lsassy/dumper.py
@@ -31,7 +31,7 @@ class Dumper:
             self._log.error("Incorrect dump method. Currently supported : procdump, dll")
             exit(1)
 
-        self._log.success("Process lsass.exe was successfully dumped")
+        self._log.success("Process lsass.exe is being dumped")
         return (self._share + self._tmp_dir + self._remote_lsass_dump).replace("\\", "/")
 
     def dlldump(self):

--- a/lsassy/impacketconnection.py
+++ b/lsassy/impacketconnection.py
@@ -85,7 +85,7 @@ class ImpacketConnection:
                 self._log.debug("File {} opened".format(fpath))
                 return fid
             except Exception as e:
-                if str(e).find('STATUS_SHARING_VIOLATION') >= 0:
+                if str(e).find('STATUS_SHARING_VIOLATION') >= 0 or str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') >= 0:
                     # Output not finished, let's wait
                     time.sleep(2)
                 else:

--- a/lsassy/impacketconnection.py
+++ b/lsassy/impacketconnection.py
@@ -80,6 +80,7 @@ class ImpacketConnection:
     def openFile(self, tid, fpath):
         while True:
             try:
+                self._log.debug("File {} opening".format(fpath))
                 fid = self.conn.openFile(tid, fpath, desiredAccess=FILE_READ_DATA)
                 self._log.debug("File {} opened".format(fpath))
                 return fid


### PR DESCRIPTION
- A task is launched to dump lsass.exe. As long as it is not finished, the dump file is non-existent or empty. This can generate STATUS_OBJECT_NAME_NOT_FOUND errors. Because of this, we have to wait until the task and the write are finished.
- Delete dump file
- More precise logging