### PR TITLE
Added netaddr to setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,12 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# virtualenv
+env
+.env
+venv
+.venv
+
 # IDE
 .idea
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     license="MIT",
     install_requires=[
         'impacket',
+        'netaddr',
         'pypykatz>=0.3.0'
     ],
     python_requires='>=3.6',


### PR DESCRIPTION
While `netaddr` is already present in `requirements.txt`, it was missing in `setup.py`, hence produced a non-working installation.

This PR adds `netaddr` to `setup.py`.

Besides, I added common virtualenv folders to `.gitignore`.