### PR TITLE
Adding kerberos support

### DIFF
--- a/lsassy/core.py
+++ b/lsassy/core.py
@@ -19,13 +19,14 @@ lock = RLock()
 class Lsassy:
     def __init__(self,
                  hostname, username, domain="", password="", lmhash="", nthash="",
+                 kerberos=False, aesKey="", dc_ip=None,
                  log_options=Logger.Options(),
                  dump_options=Dumper.Options(),
                  parse_options=Parser.Options(),
                  write_options=Writer.Options()
                  ):
 
-        self.conn_options = ImpacketConnection.Options(hostname, domain, username, password, lmhash, nthash)
+        self.conn_options = ImpacketConnection.Options(hostname, domain, username, password, lmhash, nthash, kerberos, aesKey, dc_ip)
         self.log_options = log_options
         self.dump_options = dump_options
         self.parse_options = parse_options
@@ -173,9 +174,12 @@ class CLI:
 
         # Connection Options
         self.conn_options.hostname = self.target
-        self.conn_options.domain_name = args.domain
-        self.conn_options.username = args.username
-        self.conn_options.password = args.password
+        self.conn_options.domain_name = '' if args.domain is None else args.domain
+        self.conn_options.username = '' if args.username is None else args.username
+        self.conn_options.kerberos = args.kerberos
+        self.conn_options.aes_key = '' if args.aesKey is None else args.aesKey
+        self.conn_options.dc_ip = args.dc_ip
+        self.conn_options.password = '' if args.password is None else args.password
         if not self.conn_options.password and args.hashes:
             if ":" in args.hashes:
                 self.conn_options.lmhash, self.conn_options.nthash = args.hashes.split(":")
@@ -206,10 +210,13 @@ class CLI:
             self.conn_options.password,
             self.conn_options.lmhash,
             self.conn_options.nthash,
-            self.log_options,
-            self.dump_options,
-            self.parse_options,
-            self.write_options
+            self.conn_options.kerberos,
+            self.conn_options.aesKey,
+            self.conn_options.dc_ip,
+            log_options=self.log_options,
+            dump_options=self.dump_options,
+            parse_options=self.parse_options,
+            write_options=self.write_options
         )
         return self.lsassy.run()
 

--- a/lsassy/modules/impacketconnection.py
+++ b/lsassy/modules/impacketconnection.py
@@ -16,7 +16,8 @@ from lsassy.modules.logger import Logger
 
 class ImpacketConnection:
     class Options:
-        def __init__(self, hostname="", domain_name="", username="", password="", lmhash="", nthash="", timeout=5):
+        def __init__(self, hostname="", domain_name="", username="", password="",
+                    lmhash="", nthash="", kerberos=False, aesKey="", dc_ip=None, timeout=5):
             self.hostname = hostname
             self.domain_name = domain_name
             self.username = username
@@ -24,6 +25,9 @@ class ImpacketConnection:
             self.lmhash = lmhash
             self.nthash = nthash
             self.timeout = timeout
+            self.kerberos = kerberos
+            self.aesKey = aesKey
+            self.dc_ip = dc_ip
 
     def __init__(self, options: Options):
         self.options = options
@@ -33,6 +37,9 @@ class ImpacketConnection:
         self.password = options.password
         self.lmhash = options.lmhash
         self.nthash = options.nthash
+        self.kerberos = options.kerberos
+        self.aesKey = options.aesKey
+        self.dc_ip = options.dc_ip
         self.timeout = options.timeout
         self._log = Logger(self.hostname)
         self._conn = None
@@ -52,16 +59,25 @@ class ImpacketConnection:
             return RetCode(ERROR_DNS_ERROR, e)
 
         try:
-            self._conn = SMBConnection(ip, ip, timeout=self.timeout)
+            self._conn = SMBConnection(self.hostname, ip, timeout=self.timeout)
         except Exception as e:
             return RetCode(ERROR_CONNECTION_ERROR, e)
 
-        username = self.username.split("@")[0]
-        self._log.debug("Authenticating against {}".format(ip))
+        username = ''
+        if not self.kerberos:
+            username = self.username.split("@")[0]
+            self._log.debug("Authenticating against {}".format(ip))
+        else:
+            self._log.debug("Authenticating against {}".format(self.hostname))
+
         try:
-            self._conn.login(username, self.password, domain=self.domain_name, lmhash=self.lmhash, nthash=self.nthash, ntlmFallback=True)
+            if self.kerberos:
+                self._conn.kerberosLogin(username, self.password, self.domain_name, self.lmhash, self.nthash, self.aesKey, self.dc_ip)
+            else:
+                self._conn.login(username, self.password, domain=self.domain_name, lmhash=self.lmhash, nthash=self.nthash, ntlmFallback=True)
         except SessionError as e:
-            self._log.debug("Provided credentials : {}\\{}:{}".format(self.domain_name, username, self.password))
+            if not self.kerberos:
+                self._log.debug("Provided credentials : {}\\{}:{}".format(self.domain_name, username, self.password))
             return RetCode(ERROR_LOGIN_FAILURE, e)
         except Exception as e:
             return RetCode(ERROR_UNDEFINED, e)

--- a/lsassy/modules/impacketconnection.py
+++ b/lsassy/modules/impacketconnection.py
@@ -9,6 +9,7 @@ from socket import getaddrinfo, gaierror
 
 from impacket.smb3structs import FILE_READ_DATA
 from impacket.smbconnection import SMBConnection, SessionError
+from impacket.krb5.types import KerberosException
 
 from lsassy.utils.defines import *
 from lsassy.modules.logger import Logger
@@ -76,8 +77,10 @@ class ImpacketConnection:
             else:
                 self._conn.login(username, self.password, domain=self.domain_name, lmhash=self.lmhash, nthash=self.nthash, ntlmFallback=True)
         except SessionError as e:
-            if not self.kerberos:
-                self._log.debug("Provided credentials : {}\\{}:{}".format(self.domain_name, username, self.password))
+            self._log.debug("Provided credentials : {}\\{}:{}".format(self.domain_name, username, self.password))
+            return RetCode(ERROR_LOGIN_FAILURE, e)
+        except KerberosException as e:
+            self._log.debug("Kerberos error")
             return RetCode(ERROR_LOGIN_FAILURE, e)
         except Exception as e:
             return RetCode(ERROR_UNDEFINED, e)

--- a/lsassy/modules/logger.py
+++ b/lsassy/modules/logger.py
@@ -19,6 +19,12 @@ class Logger:
         self._align = options.align
         self._verbosity = options.verbosity
         self._quiet = options.quiet
+        if self._verbosity == 2:
+            # This part is to have impacket debug informations
+            import logging
+            from impacket.examples import logger
+            logger.init()
+            logging.getLogger().setLevel(logging.DEBUG)
 
     def info(self, msg):
         if not self._quiet:

--- a/lsassy/utils/utils.py
+++ b/lsassy/utils/utils.py
@@ -46,6 +46,15 @@ def get_args():
     group_auth.add_argument('-p', '--password', action='store', help='Plaintext password')
     group_auth.add_argument('-d', '--domain', default="", action='store', help='Domain name')
     group_auth.add_argument('-H', '--hashes', action='store', help='[LM:]NT hash')
+    group_auth.add_argument('-k', '--kerberos', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
+                                                    '(KRB5CCNAME) based on target parameters. If valid credentials '
+                                                    'cannot be found, it will use the ones specified in the command '
+                                                    'line')
+    group_auth.add_argument('-dc-ip', action='store', metavar="ip address",
+                       help='IP Address of the domain controller. If omitted it will use the domain part (FQDN) specified in '
+                            'the target parameter')
+    group_auth.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
+                                                                    '(128 or 256 bits)')
 
     group_out = parser.add_argument_group('output')
     group_out.add_argument('-o', '--outfile', action='store', help='Output credentials to file')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -33,6 +33,13 @@ class test_impacketconnection(unittest.TestCase):
         self.assertIsInstance(ret, RetCode)
         self.assertEqual(ERROR_DNS_ERROR[1], ret.error_msg)
 
+    def test_login_kerberos_success(self):
+        self.conn = ImpacketConnection(ImpacketConnection.Options(ip_address, domain, da_login, da_password, '', '', kerberos, ''))
+        self.conn.set_logger(self.log)
+        ret = self.conn.login()
+        self.assertIsInstance(ret, RetCode)
+        self.assertEqual(ERROR_SUCCESS[1], ret.error_msg)
+
     def test_login_connection_error(self):
         self.conn = ImpacketConnection(ImpacketConnection.Options("255.255.255.255", domain, da_login, da_password))
         self.conn.set_logger(self.log)

--- a/tests/tests_config.py.template
+++ b/tests/tests_config.py.template
@@ -27,3 +27,6 @@ usr_password = "YouDontWannaMessWithMe"
 # Local tools for dumping methods (empty to skip tests)
 procdump_path = "/home/pixis/Tools/Windows/Sysinternals/procdump.exe"
 dumpert_path = "/home/pixis/Tools/Windows/Dumpert/Outflank-Dumpert.exe"
+
+# Include kerberos tests
+kerberos = True


### PR DESCRIPTION
Adding kerberos support, all methods except the dumpert have been tested on one target.
The unit tests have not been reworked, only one authentication test using kerberos has been added but a TGT must be correctly created and set using the KRB5CCNAME environment variable before running the tests.