### PR TITLE
Multiple output fixes

### DIFF
--- a/lsassy/core.py
+++ b/lsassy/core.py
@@ -104,14 +104,11 @@ class Lsassy:
         self._log.info("Cleaning complete")
 
     def get_credentials(self):
-        self.log_options.quiet = True
-        self.log_options.verbosity = False
-        self._log = Logger(self._target, self.log_options)
-        self.write_options.format = "none"
         return_code = self.run()
+        self._writer = Writer(self._target, self._credentials, self._log, self.write_options)
         ret = {
                 "success": True,
-                "credentials": self._credentials
+                "credentials": self._writer.get_output()
             }
         if not return_code.success():
             ret["success"] = False
@@ -195,6 +192,7 @@ class CLI:
         # Writer Options
         self.write_options.output_file = args.outfile
         self.write_options.format = args.format
+        self.write_options.quiet = args.quiet
 
     def run(self):
         args = get_args()

--- a/lsassy/modules/logger.py
+++ b/lsassy/modules/logger.py
@@ -44,13 +44,12 @@ class Logger:
             print("\033[1;31m[X]\033[0m [{}]{}{}".format(self._target, " "*self._align, msg), file=sys.stderr)
 
     def success(self, msg, output=True):
+        msg = "\n    ".join(msg.split("\n"))
+        out = "\033[1;32m[+]\033[0m [{}]{}{}".format(self._target, " "*self._align, msg)
         if not self._quiet:
-            msg = "\n    ".join(msg.split("\n"))
-            out = "\033[1;32m[+]\033[0m [{}]{}{}".format(self._target, " "*self._align, msg)
             if output:
                 print(out)
-            else:
-                return out
+        return out
 
     def raw(self, msg):
         print("{}".format(msg), end='')


### PR DESCRIPTION
This pull request fix some stuff:
* The Writer is now correctly using the quiet argument, thus, using the `-q` switch will completely remove the output. This would be the intended behavior when used with the `-o` option
* The `get_credentials` method has been reworked a bit to ensure options passed to the `Lsassy` class are correctly used. This ensure the `examples/get_credentials.py` script is working as inteded. Also the format is now correclty used for the output.
* The Writer would not crash anymore when used with the `quiet` switch and the `pretty` output format.
