### PR TITLE
Release the DCOM Connection if WMI failed

### DIFF
--- a/lsassy/exec/wmi.py
+++ b/lsassy/exec/wmi.py
@@ -61,6 +61,8 @@ class WMI:
             self.dcom.disconnect()
             raise KeyboardInterrupt(e)
         except Exception as e:
+            if self.dcom is not None:
+                self.dcom.disconnect()
             raise Exception("WMIEXEC not supported on host %s : %s" % (self.conn.hostname, e))
 
     def execute(self, commands):


### PR DESCRIPTION
This would cause python to hang when  the WMI exec method failed during the program execution (lsassy in CLI or any python code using Lsassy as a lib).
That was a funny debugging afternoon 😄 

Cheers