### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.7"
 netaddr = "^0.8.0"
 pypykatz = "^0.6.3"
 impacket = ">= 0.10.0"
-rich = "^10.6.0"
+rich = ">=10.6.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.1"


### PR DESCRIPTION
netexec 1.1.0+9662ef6 depends on rich<14.0.0 and >=13.3.5 lsassy 3.1.10 depends on rich<11.0.0 and >=10.6.0

https://github.com/Pennyw0rth/NetExec/issues/252