### PR TITLE
Use session port for SMB exec methods

### DIFF
--- a/lsassy/exec/smb.py
+++ b/lsassy/exec/smb.py
@@ -88,7 +88,7 @@ class Exec(IExec):
             stringbinding = r"ncacn_np:%s[\pipe\svcctl]" % self.session.address
             lsassy_logger.debug("StringBinding %s" % stringbinding)
             self._rpctransport = transport.DCERPCTransportFactory(stringbinding)
-            self._rpctransport.set_dport(445)
+            self._rpctransport.set_dport(self.session.port)
             self._rpctransport.setRemoteHost(self.session.address)
             if hasattr(self._rpctransport, "set_credentials"):
                 # This method exists only for selected protocol sequences.

--- a/lsassy/exec/smb_stealth.py
+++ b/lsassy/exec/smb_stealth.py
@@ -121,7 +121,7 @@ class Exec(IExec):
             stringbinding = r"ncacn_np:%s[\pipe\svcctl]" % self.session.address
             lsassy_logger.debug("StringBinding %s" % stringbinding)
             self._rpctransport = transport.DCERPCTransportFactory(stringbinding)
-            self._rpctransport.set_dport(445)
+            self._rpctransport.set_dport(self.session.port)
             self._rpctransport.setRemoteHost(self.session.address)
             if hasattr(self._rpctransport, "set_credentials"):
                 # This method exists only for selected protocol sequences.


### PR DESCRIPTION
lsassy already accepts --port, and Session already stores that value in self.session.port. However, the SMB-based execution paths in lsassy/exec/smb.py and lsassy/exec/smb_stealth.py ignored it and reopened the RPC transport with set_dport(445). That breaks scenarios where SMB is exposed through a non-default 445 port such as port forwarding

This change replaces the hardcoded 445 with self.session.port in both SMB exec implementations. With that adjustment, lsassy works correctly when invoked with a custom SMB port like --port 4445, while preserving the default behavior for 445

Before:
<img width="1541" height="612" alt="image" src="https://github.com/user-attachments/assets/9c8ffde8-7620-4eda-a178-27b57cf0f2c6" />
After:
<img width="1735" height="591" alt="image" src="https://github.com/user-attachments/assets/669dbb14-6cf3-4da8-b48d-9e10c9a18536" />